### PR TITLE
docs: release notes for ${VERSION}

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -3,6 +3,7 @@
 
 * [Quick Start Guide](./docs/getting-started/quick-start-guide.md)
 * [Release notes](./docs/release-notes/README.md)
+* [v0.1.99](./docs/release-notes/release-v0.1.99.md)
   * [v2.1.4](./docs/release-notes/release-v2.1.4.md)
   * [v2.1.3](./docs/release-notes/release-v2.1.3.md)
   * [v2.1.2](./docs/release-notes/release-v2.1.2.md)

--- a/docs/release-notes/release-v0.1.99.md
+++ b/docs/release-notes/release-v0.1.99.md
@@ -1,0 +1,14 @@
+<h1 style="display:flex; justify-content: space-between; align-items: center;">
+KubeKit v0.1.99
+<span id="release-date" style="font-size:medium; font-weight:normal; font-style:italic;">Dec 18, 2025</span>
+</h1>
+
+## What's Changed
+* Fix ssr package runtime load issue by @GRCR in https://github.com/kube-kit/kube-kit/pull/466
+* Add workflow to sync release notes to documentation by @FarhanTausif in https://github.com/kube-kit/kube-kit/pull/469
+* Sync release notes by @FarhanTausif in https://github.com/kube-kit/kube-kit/pull/471
+
+## New Contributors
+* @FarhanTausif made their first contribution in https://github.com/kube-kit/kube-kit/pull/469
+
+**Full Changelog**: https://github.com/kube-kit/kube-kit/compare/v2.1.2...v0.1.99


### PR DESCRIPTION
Auto-generated release notes for **${VERSION}**.
Source: GitHub Release from kube-kit/kube-kit.